### PR TITLE
Update speedtest.sh

### DIFF
--- a/speedtest.sh
+++ b/speedtest.sh
@@ -1,9 +1,9 @@
-#!/bin/bash
+#!/bin/sh
 # Licensed under GPLv3
 # created by "black" on LET
 # please give credit if you plan on using this for your own projects 
 
-fileName="100mb.test";
+fileName="10mb.test";
 #check if user wants 100MB files instead
 ##NOTE: testing with 100MB by default
 #ls "FORCE100MBFILESPEEDTEST" 2>/dev/null 1>/dev/null;
@@ -15,205 +15,203 @@ fileName="100mb.test";
 #	rm FORCE100MBFILESPEEDTEST;
 #fi
 
+# TODO: test connectivity using /dev/tcp
+
+timeout='2'
+fifo='yourfile'
+
+do_dd() {
+  dd if='/dev/urandom' bs=1M count=10 2>/dev/null > "$fifo"
+}
+
+timeout() {
+local timeout_secs=${1:-10}
+shift
+
+# subshell
+( 
+  "$@" &
+  child=$!     #trap - '' SIGTERM #why would we need this?
+  (       
+	sleep $timeout_secs
+	kill $child 2> /dev/null # TODO returns 143 instead of "real" timeout's 124
+  ) &
+  wait $child
+)
+}
+export timeout
+
+#TODO: select on best ping
+
+get_sites() {
+  sort -R<<EOM
+100.42.19.110;Speedtest from Portland, Oregon, USA [ generously donated by http://bonevm.com ] on a shared 100 Mbps port
+23.226.231.112;Speedtest from Seattle, Washington, USA [ generously donated by http://ramnode.com ] on on a shared 1 Gbps port
+107.150.31.36;Speedtest from Los Angeles, CA, USA [ generously donated by http://maximumvps.net ] on a shared 1 Gbps port
+208.67.5.186:10420;Speedtest from Kansas City, MO, USA [ generously donated by http://megavz.com ] on a shared 1 Gbps port
+198.50.209.250;Speedtest from Beauharnois, Quebec, Canada [ generously donated by http://mycustomhosting.net ] on a shared 1000 Mbps port in / 500 Mbps port out
+168.235.78.99;Speedtest from Los Angeles, [California], USA, generously donated by http://ramnode.com on on a shared 1 Gbps port
+192.210.229.206;Speedtest from Chicago, IL, USA, generously donated by http://vortexservers.com on a shared 1 Gbps port
+167.114.135.10;Speedtest from Beauharnois, Quebec, Canada [ generously donated by http://hostnun.net/ ] on a shared 500 Mbps port
+192.111.152.114:2020;Speedtest from Lenoir, NC, USA, generously donated by http://megavz.com on a shared 1 Gbps port
+aj1dddzidccbez4i9fh3evs0tyj.getipaddr.net;Speedtest from Denver, CO, USA on a shared 100 Mbps port
+162.220.26.107;Speedtest from Dallas, TX, USA, generously donated by http://cloudshards.com on a shared 1 Gbps port
+168.235.81.120;Speedtest from New York City, New York, USA generously donated by http://ramnode.com on on a shared 1 Gbps port
+192.73.235.56;Speedtest from Atlanta, Georgia, USA [ generously donated by http://ramnode.com ] on on a shared 1 Gbps port
+162.219.26.75:12320;Speedtest from  Asheville, NC, USA on a shared 1 Gbps port
+107.155.187.129;Speedtest from Jacksonville, FL, USA [ generously donated by http://maximumvps.net ] on a shared 1 Gbps port
+EOM
+}
+
 ##need sed now because some european versions of curl insert a , in the speed results
-speedtest () {
-	dlspeed=$(echo -n "scale=2; " && curl --connect-timeout 8 http://$1/$fileName -w "%{speed_download}" -o $fileName -s | sed "s/\,/\./g" && echo "/1048576");
-	echo "$dlspeed" | bc -q | sed "s/$/ MB\/sec/;s/^/\tDownload Speed\: /";
-	ulspeed=$(echo -n "scale=2; " && curl --connect-timeout 8 -F "file=@$fileName" http://$1/webtests/ul.php -w "%{speed_upload}" -s -o /dev/null | sed "s/\,/\./g" && echo "/1048576");
-	echo "$ulspeed" | bc -q | sed "s/$/ MB\/sec/;s/^/\tUpload speed\: /";
+test_speed () {
+  local _PROTO _NOPROTO _SRVPORT _SRV _PORT _PATH _ADDR _COMMENT
+  
+  _ADDR=${1%%;*}
+  _COMMENT=${1##*;}
+  
+  _PROTO=${_ADDR=%%:*}
+  _NOPROTO=${_ADDR=#*//}
+  _SRVPORT=${_NOPROTO%%/*}
+  _SRV=${_SRVPORT%%:*}
+  
+  if [ $(echo $_SRVPORT | grep ':') ]; then
+    _PORT=${_SRVPORT##*:}
+  else
+    _PORT=80
+  fi
+  
+  echo -n "Testing connection to $_SRV $_PORT"
+  echo " "| timeout 2 nc $_SRV $_PORT >/dev/null 2>&1 || { echo "...failure"; return 1; }
+  echo "...success"
+  
+  dlspeed="$(curl --connect-timeout $timeout "http://${_SRV}:${_PORT}/$fileName" -w "%{speed_download}" -o /dev/null -s| sed "s/\,/\./g" && echo "/131072")"
+  echo "$dlspeed" | bc -q | sed "s/$/ Mbit\/sec/;s/^/\tDownload Speed\: /"
+	
+  do_dd&
+  ulspeed="$(curl --connect-timeout $timeout -d @$fifo "http://${_SRV}:${_PORT}/webtests/ul.php" -w "%{speed_upload}" -s -o /dev/null | sed "s/\,/\./g" && echo "/131072")"
+	echo "$ulspeed" | bc -q | sed "s/$/ Mbit\/sec/;s/^/\tUpload speed\: /"
+  
+  # empty the fifo?
 }
 
-ls "$fileName" 1>/dev/null 2>/dev/null;
-if [ $? -eq 0 ]
-then
-	echo "$fileName already exists, remove it or rename it";
-	exit 1;
-fi
+PING_DCS="speedtest.atlanta.linode.com speedtest-sfo1.digitalocean.com speedtest.newark.linode.com speedtest-nyc2.digitalocean.com speedtest.fremont.linode.com"
 
-cputest () {
-	cpuName=$(cat /proc/cpuinfo | grep "model name" | cut -d ":" -f2 | tr -s " " | head -n 1);
-	cpuCount=$(cat /proc/cpuinfo | grep "model name" | cut -d ":" -f2 | wc -l);
-	echo "CPU: $cpuCount x$cpuName";
-	echo -n "Time taken to generate PI to 5000 decimal places with a single thread: ";
-	(time echo "scale=5000; 4*a(1)" | bc -lq) 2>&1 | grep real |  cut -f2
+# prereq testing
+for which_cmd in curl bc nc; do
+  if ! [ $(which "$which_cmd") ]; then
+    echo "This script requires $which_cmd"
+    exit 1
+  fi
+done
+
+# PATTERN="\([0-9.]\+ [KMG]B/s\)"
+
+test_latency() {
+  for dc in $PING_DCS; do
+    PING=$(ping -c4 $dc | awk -F\/ '/^(rtt|round-trip)/ {print $5}')
+    echo "${dc}: Latency: $PING ms"
+  done
 }
 
-disktest () {
-	echo "Writing 1000MB file to disk"
-	dd if=/dev/zero of=$$.disktest bs=64k count=16k conv=fdatasync 2>&1 | tail -n 1 | cut -d " " -f3-;
-	rm $$.disktest;
+
+cputest() {
+  cpuName=$(cat /proc/cpuinfo | grep "model name" | cut -d ":" -f2 | tr -s " " | head -n 1)
+  cpuCount=$(cat /proc/cpuinfo | grep "model name" | cut -d ":" -f2 | wc -l)
+  echo "CPU: $cpuCount x$cpuName"
+  echo -n "Time taken to generate PI to 5000 decimal places with a single thread: "
+  time echo "scale=5000; 4*a(1)" | bc -lq 2>&1 | grep real |  cut -f2
 }
 
-#check dependencies
-metDependencies=1;
-#check if curl is installed
-type curl 1>/dev/null 2>/dev/null;
-if [ $? -ne 0 ]
-then
-	echo "curl is not installed, install it to continue, typically you can install it by typing"
-	echo "apt-get install curl"
-	echo "yum install curl"
-	echo "depending on your OS";
-	metDependencies=0 ;
-fi
-#check if bc is installed
-type bc 1>/dev/null 2>/dev/null;
-if [ $? -ne 0 ]
-then
-	echo "bc is not installed, install it to continue, typically you can install it by typing"
-	echo "apt-get install bc"
-	echo "yum install bc"
-	echo "depending on your OS";
-	metDependencies=0;
-fi
-if [ $metDependencies -eq 0 ]
-then
-	exit 1;
-fi
+disktest() {
+  size=5
+  echo "Writing $size file to disk"
+  dd if=/dev/zero of=$$.disktest bs=1M count=$size conv=fdatasync 2>&1 | tail -n 1 | cut -d " " -f3-
+  rm $$.disktest
+}
 
+main() {
+  [ -e "$fifo" ] && rm -f "$fifo"
+  
+  for func in $queue; do
+    $func
+  done
 
-## start speed test
-echo "-------------Speed test--------------------";
+  mkfifo "$fifo"
+  ## start speed test
+  echo "-------------Speed test $(date)--------------------"
 
-echo "Testing North America locations";
+  get_sites | while read site; do
+    test_speed "$site"
+  done
 
-### Portland, Oregon, USA (donated by http://bonevm.com)
-echo "Speedtest from Portland, Oregon, USA [ generously donated by http://bonevm.com ] on a shared 100 Mbps port";
-speedtest 100.42.19.110;
+  rm -f "$fifo"
+}
 
-## Seattle, Washington, USA (donated by http://ramnode.com)
-echo "Speedtest from Seattle, Washington, USA [ generously donated by http://ramnode.com ] on on a shared 1 Gbps port";
-speedtest 23.226.231.112;
+queue=''
+while getopts "lcdv" OPT; do
+  case "$OPT" in
+    'l')
+      queue="$queue test_latency "
+      ;;
+    'c')                                                                                           
+      queue="$queue test_cpu "                                                                       
+      ;;
+    'd')                                                                                           
+      queue="$queue test_disk "                                                                       
+      ;;
+    'v')
+      VERBOSE='true'
+      ;;
+    esac
+  done
+  
+echo $queue
 
-### Los Angeles, CA, USA (donated by http://maximumvps.net)
-echo "Speedtest from Los Angeles, CA, USA [ generously donated by http://maximumvps.net ] on a shared 1 Gbps port";
-speedtest 107.150.31.36;
-
-### LA, CA, USA (donated by http://terafire.net)
-#echo "Speedtest from Los Angeles, CA, USA [ generously donated by TeraFire, LLC ] on a shared 1 Gbps port";
-#speedtest 162.216.226.220;
-
-## Los Angeles, California, USA (donated by http://ramnode.com)
-echo "Speedtest from Los Angeles, California, USA [ generously donated by http://ramnode.com ] on on a shared 1 Gbps port";
-speedtest 168.235.78.99;
-
-##Denver, CO, USA
-echo "Speedtest from Denver, CO, USA on a shared 100 Mbps port";
-speedtest aj1dddzidccbez4i9fh3evs0tyj.getipaddr.net;
-
-##Kansas City, MO, USA
-echo "Speedtest from Kansas City, MO, USA [ generously donated by http://megavz.com ] on a shared 1 Gbps port";
-speedtest 208.67.5.186:10420;
-
-### Dallas, TX, USA (donated by http://cloudshards.com)
-echo "Speedtest from Dallas, TX, USA [ generously donated by http://cloudshards.com ] on a shared 1 Gbps port";
-speedtest 162.220.26.107;
-
-### Chicago, IL, USA (donated by http://vortexservers.com)
-echo "Speedtest from Chicago, IL, USA [ generously donated by http://vortexservers.com ] on a shared 1 Gbps port";
-speedtest 192.210.229.206;
-
-##Beauharnois, Quebec, Canada (donated by http://http://mycustomhosting.net)
-echo "Speedtest from Beauharnois, Quebec, Canada [ generously donated by http://mycustomhosting.net ] on a shared 1000 Mbps port in / 500 Mbps port out";
-speedtest 198.50.209.250;
-
-##Beauharnois, Quebec, Canada (donated by hostnun)
-echo "Speedtest from Beauharnois, Quebec, Canada [ generously donated by http://hostnun.net/ ] on a shared 500 Mbps port";
-speedtest 167.114.135.10;
-
-## New York City, New York, USA (donated by http://ramnode.com)
-echo "Speedtest from New York City, New York, USA [ generously donated by http://ramnode.com ] on on a shared 1 Gbps port";
-speedtest 168.235.81.120;
-
-## Buffalo, NY, USA
-#echo "Speedtest from Buffalo, NY, USA on a shared 1 Gpbs port (location may be slow)":
-#speedtest 23.94.28.158;
-
-## Atlanta, Georgia, USA (donated by http://ramnode.com)
-echo "Speedtest from Atlanta, Georgia, USA [ generously donated by http://ramnode.com ] on on a shared 1 Gbps port";
-speedtest 192.73.235.56;
-
-## Atlanta, GA, USA (donated by  http://hostus.us)
-#echo "Speedtest from Atlanta, GA, USA [ generously donated by http://hostus.us ] on a shared 1 Gbps port";
-#speedtest 162.245.216.241;
-
-## Lenoir, NC, USA (donated by http://megavz.com
-echo "Speedtest from Lenoir, NC, USA [ generously donated by http://megavz.com ] on a shared 1 Gbps port";
-speedtest 192.111.152.114:2020;
-
-## Asheville, NC, USA
-echo "Speedtest from  Asheville, NC, USA on a shared 1 Gbps port";
-speedtest 162.219.26.75:12320;
-
-##Jacksonville, FL, USA (donated by http://maximumvps.net)
-echo "Speedtest from Jacksonville, FL, USA [ generously donated by http://maximumvps.net ] on a shared 1 Gbps port";
-speedtest 107.155.187.129;
-
-
-echo -e "\nTesting EU locations";
-
-### Paris, France
-echo "Speedtest from Paris, France on a shared 1 Gbps port";
-speedtest "4iil8b4g67f03cdecaw9nusv.getipaddr.net";
-
-## Alblasserdam, Netherlands (donated by http://ramnode.com)
-echo "Speedtest from Alblasserdam, Netherlands [ generously donated by http://ramnode.com ] on on a shared 1 Gbps port";
-speedtest 185.52.0.68;
-
-### Dusseldorf, Germany (donated by http://megavz.com)
-echo "Speedtest from Dusseldorf, Germany [ generously donated by http://megavz.com ] on a shared 1 Gbps port";
-speedtest 130.255.188.37:7020;
-
-### Falkenstein, Germany (donated by http://megavz.com)
-echo "Speedtest from Falkenstein, Germany [ generously donated by http://megavz.com ] on a shared 1 Gbps port";
-speedtest 5.9.2.36:12120;
-
-### Bucharest, Romania
-echo "Speedtest from Bucharest, Romania [ generously donated by http://www.prometeus.net ] on a semi-dedicated 1 Gbps port";
-speedtest "servoni.eu/webtests";
-
-echo -e "\nTesting Asian locations";
-
-### Singapore
-echo "Speedtest from Singapore on a shared 1 Gbps port";
-speedtest 128.199.65.191;
-
-unlink $fileName;
-
-### Due to expensive bandwidth, use the 10MB test file instead
-fileName="10mb.test";
-
-ls "$fileName" 1>/dev/null 2>/dev/null;
-if [ $? -eq 0 ]
-then
-        echo "$fileName already exists, remove it or rename it";
-        exit 1;
-fi
-
-### Tokyo, Japan
-echo "Speedtest from Tokyo, Japan on a shared 1 Gbps port";
-speedtest 108.61.200.70:12601;
-
-echo -e "\nTesting Australian locations";
-
-### Sydney, Australia
-echo "Speedtest from Sydney, Australia on a shared 1 Gbps port";
-speedtest 103.25.58.8:3310;
-
-unlink $fileName;
-
-## start CPU test
-echo "---------------CPU test--------------------";
-cputest;
-
-## start disk test
-echo "----------------IO test-------------------";
-disktest;
+main
 
 ##hints
-echo -e "If you need to speedtest in a specific region:
-http://dl.getipaddr.net/speedtest.NA.sh for North America
-http://dl.getipaddr.net/speedtest.EU.sh for Europe
-http://dl.getipaddr.net/speedtest.Asia.sh for Asia
-http://dl.getipaddr.net/speedtest.AU.sh for Australia";
+#echo -e "If you need to speedtest in a specific region:
+#http://dl.getipaddr.net/speedtest.NA.sh for North America
+#http://dl.getipaddr.net/speedtest.EU.sh for Europe
+#http://dl.getipaddr.net/speedtest.Asia.sh for Asia
+#http://dl.getipaddr.net/speedtest.AU.sh for Australia";
 
+#echo -e "\nTesting EU locations";
+
+### Paris, France
+#echo "Speedtest from Paris, France on a shared 1 Gbps port";
+#speedtest "4iil8b4g67f03cdecaw9nusv.getipaddr.net";
+
+## Alblasserdam, Netherlands (donated by http://ramnode.com)
+#echo "Speedtest from Alblasserdam, Netherlands [ generously donated by http://ramnode.com ] on on a shared 1 Gbps port";
+#speedtest 185.52.0.68;
+
+### Dusseldorf, Germany (donated by http://megavz.com)
+#echo "Speedtest from Dusseldorf, Germany [ generously donated by http://megavz.com ] on a shared 1 Gbps port";
+#speedtest 130.255.188.37:7020;
+
+### Falkenstein, Germany (donated by http://megavz.com)
+#echo "Speedtest from Falkenstein, Germany [ generously donated by http://megavz.com ] on a shared 1 Gbps port";
+#speedtest 5.9.2.36:12120;
+
+### Bucharest, Romania
+#echo "Speedtest from Bucharest, Romania [ generously donated by http://www.prometeus.net ] on a semi-dedicated 1 Gbps port";
+#speedtest "servoni.eu/webtests";
+
+#echo -e "\nTesting Asian locations";
+
+### Singapore
+#echo "Speedtest from Singapore on a shared 1 Gbps port";
+#speedtest 128.199.65.191;
+
+
+### Tokyo, Japan
+#echo "Speedtest from Tokyo, Japan on a shared 1 Gbps port";
+#speedtest 108.61.200.70:12601;
+
+#echo -e "\nTesting Australian locations";
+
+### Sydney, Australia
+#echo "Speedtest from Sydney, Australia on a shared 1 Gbps port";
+#speedtest 103.25.58.8:3310;


### PR DESCRIPTION
- POSIX compat for non-bash shells
- flag support to enable/disable certain checks
- precheck sites before attempting
- custom timeout() for devices that don't have timeout
- do not touch disk, use `dd` to pipe
- randomized test sites
- change to Mbit/sec as this is the most-common used by ISP advertisement